### PR TITLE
Added RESPONSE_CACHE_ENABLED flag to config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ This is the contents of the published config file:
 return [
 
     /**
+     *  This is the master switch to enable of disable the response cache. If set to
+     *  false no responses will be cached.
+     */
+    'enabled' => env('RESPONSE_CACHE_ENABLED', true),
+
+    /**
      *  The given class will determinate if a request should be cached. The
      *  default class will cache all successful GET-requests.
      *


### PR DESCRIPTION
This PR:
- adds the master switch configuration ability to the README.md example of the default configuration file

It's part of the config file that gets generated by the package automatically, so that is now reflected in the example.
Hopefully this helps you from having to answer that same question again that I asked this morning :-)

(Reference: https://github.com/spatie/laravel-responsecache/issues/15)
